### PR TITLE
bug in meltdown.c outputting "PCID Invalidation"

### DIFF
--- a/source/meltdown.c
+++ b/source/meltdown.c
@@ -66,7 +66,7 @@ show_meltdown_tab(struct nk_context *ctx, struct style *style, struct meltdown_i
 	nk_label_wrap(ctx, "PCID Invalidation:");
 	ui_set_font(ctx, style->font);
 
-	if (info->has_pcid) {
+	if (info->has_invpcid) {
 		nk_label_wrap(ctx, "Yes");
 	} else {
 		nk_label_wrap(ctx, "No");


### PR DESCRIPTION
the meltdown file repeated queries to the "info" struct for "has_pcid" TWICE, where the 2nd one should be outputting the field "has_invpcid" for the "PCID Invalidation:" section.