### PR TITLE
Report memory using binary prefixes

### DIFF
--- a/source/system.c
+++ b/source/system.c
@@ -20,7 +20,7 @@ query_sys_info(struct sys_info *info)
 	info->cpu_name = cpuid_get_brand_string();
 	info->os_name = get_os_name();
 	info->microcode = get_microcode();
-	info->memory = get_memory_size(0, 2);
+	info->memory = get_memory_size(1, 2);
 
 	return 0;
 }


### PR DESCRIPTION
This results in a reported memory size which matches advertised
values, instead of e.g. a system with 32 GiB reporting over 34 GB
(which is correct but potentially surprising).

Signed-off-by: Stephen Kitt <steve@sk2.org>